### PR TITLE
Additional Fixes  in Lab-4

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 TrueSight Intelligence Lab
 ==========================
-__version 0.8.7__
+__version 0.8.8__
 
 Virtual machine lab environment for learning about TrueSight Intelligence.
 

--- a/docs/labs/lab4.md
+++ b/docs/labs/lab4.md
@@ -487,7 +487,7 @@ To run the script `labs/lab-4/ex-4-2.metrics.py`.
 2. Run the following:
 
     ```
-    $ labs/lab-3/ex-4-2.metrics.py
+    $ labs/lab-4/ex-4-2.metrics.py
     ```
 
 example output from running the script is shown here:

--- a/labs/lab-4/ex4-3.metrics.py
+++ b/labs/lab-4/ex4-3.metrics.py
@@ -196,7 +196,8 @@ class ETL(object):
         :param measurements:
         :return:
         """
-        logging.debug("Sending {0} measurements".format(row_count))
+        measurement_count = len(measurements)
+        logging.debug("Sending {0} measurements".format(measurement_count))
         self.api.measurement_create_batch(measurements)
 
     def process_records(self):
@@ -267,6 +268,7 @@ class ETL(object):
                 self.process_data()
         except filelock.Timeout:
             self.log('Extraction process running skipping')
+
 
 if __name__ == '__main__':
     etl = ETL(lock_file_path='etl.lock',


### PR DESCRIPTION
- Undefined variable when logging the number of measurements sent using the api in Lab 4 exercise 3.
- Typo in the documentation that had incorrect directory.
